### PR TITLE
Change bin name for macos

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -6,7 +6,7 @@ rm -f ./bin/FluidX3D.exe # prevent execution of old version if compiling fails
 #g++ ./src/*.cpp -o ./bin/FluidX3D.exe -std=c++17 -pthread -I./src/OpenCL/include -L./src/OpenCL/lib -lOpenCL -I./src/X11/include -L./src/X11/lib -lX11 # compile on Linux with X11
 
 g++ ./src/*.cpp -o ./bin/FluidX3D.exe -std=c++17 -pthread -I./src/OpenCL/include -L./src/OpenCL/lib -lOpenCL # compile on Linux (without X11)
-#g++ ./src/*.cpp -o ./bin/FluidX3D.exe -std=c++17 -pthread -I./src/OpenCL/include -framework OpenCL # compile on macOS (without X11)
+#g++ ./src/*.cpp -o ./bin/FluidX3D -std=c++17 -pthread -I./src/OpenCL/include -framework OpenCL # compile on macOS (without X11)
 #g++ ./src/*.cpp -o ./bin/FluidX3D.exe -std=c++17 -pthread -I./src/OpenCL/include -L/system/vendor/lib64 -lOpenCL # compile on Android (without X11)
 
 ./bin/FluidX3D.exe $1 # run FluidX3D


### PR DESCRIPTION
.exe is an extension format common on Windows but not on MacOS

Generating the bin without the extension is just fine

This should probably be the case for Linux as well. I wanted to see if this was OK before I fixed the script to ensure the correct bin name is used on the final line to run FluidX3D. I can simply assign to a var