### PR TITLE
make INTERACTIVE_GRAPHICS compatible with macOS

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -96,6 +96,15 @@
     ```
 
   </details>
+-- **macOS**
+  <details><summary>Apple M-series GPUs</summary>
+
+  - Download homebrew
+  - In a terminal, run:
+    ```zsh
+    brew install libxrandr quartz clang
+    ```  
+  </details>
 
 </details>
 
@@ -140,7 +149,8 @@
 - Compiling requires [`g++`](https://gcc.gnu.org/) with `C++17`, which is supported since version `8` (check with `g++ --version`). If you have [`make`](https://www.gnu.org/software/make/) installed (check with `make --version`), compiling will will be faster using multiple CPU cores; otherwise compiling falls back to using a single CPU core.
 - To select a specific GPU, enter `./make.sh 0` to compile+run, or `bin/FluidX3D 0` to run on device `0`. You can also select multiple GPUs with `bin/FluidX3D 0 1 3 6` if the setup is [configured as multi-GPU](#the-lbm-class).
 - Operating system (Linux/macOS/Android) and X11 support (required for [`INTERACTIVE_GRAPHICS`](src/defines.hpp)) are detected automatically. In case problems arise, you can still manually select [`target=...`](make.sh#L13) in [`make.sh`](make.sh#L13).
-- On macOS and Android, [`INTERACTIVE_GRAPHICS`](src/defines.hpp) mode is not supported, as no X11 is available. You can still use [`INTERACTIVE_GRAPHICS_ASCII`](src/defines.hpp) though, or [render video](#video-rendering) to the hard drive with regular [`GRAPHICS`](src/defines.hpp) mode.
+- On Android, [`INTERACTIVE_GRAPHICS`](src/defines.hpp) mode is not supported, as no X11 is available. You can still use [`INTERACTIVE_GRAPHICS_ASCII`](src/defines.hpp) though, or [render video](#video-rendering) to the hard drive with regular [`GRAPHICS`](src/defines.hpp) mode.
+- On macOS, Apple's XRandR library doesn't respond normally. If you want the FluidX3D window in a specific place, or you have a low-resolution or sub-60 Hz monitor, you'll need to edit src/graphics.cpp.
 
 <br>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -102,7 +102,7 @@
   - Download homebrew
   - In a terminal, run:
     ```zsh
-    brew install libxrandr quartz clang
+    brew install libxrandr xquartz clang
     ```  
   </details>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -102,7 +102,7 @@
   - Download homebrew
   - In a terminal, run:
     ```zsh
-    brew install libxrandr xquartz clang
+    brew install libxrandr xquartz gcc
     ```  
   </details>
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -96,7 +96,7 @@
     ```
 
   </details>
--- **macOS**
+- **macOS**
   <details><summary>Apple M-series GPUs</summary>
 
   - Download homebrew

--- a/makefile
+++ b/makefile
@@ -13,10 +13,12 @@ macOS: LDLIBS_OPENCL = -framework OpenCL
 Android: LDLIBS_OPENCL = -L/system/vendor/lib64 -lOpenCL
 
 Linux-X11: LDFLAGS_X11 = -I./src/X11/include
-Linux macOS Android: LDFLAGS_X11 =
+macOS: LDFLAGS_X11 = -I/opt/X11/include
+Linux Android: LDFLAGS_X11 =
 
 Linux-X11: LDLIBS_X11 = -L./src/X11/lib -lX11 -lXrandr
-Linux macOS Android: LDLIBS_X11 =
+macOS: LDLIBS_X11 = -L/opt/X11/lib -lX11 -lXrandr 
+Linux Android: LDLIBS_X11 =
 
 Linux-X11 Linux macOS Android: bin/FluidX3D
 

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -24,7 +24,7 @@
 //#define SUBGRID // enables Smagorinsky-Lilly subgrid turbulence LES model to keep simulations with very large Reynolds number stable
 //#define PARTICLES // enables particles with immersed-boundary method (for 2-way coupling also activate VOLUME_FORCE and FORCE_FIELD; only supported in single-GPU)
 
-//#define INTERACTIVE_GRAPHICS // enable interactive graphics; start/pause the simulation by pressing P; either Windows or Linux X11 desktop must be available; on Linux: change to "compile on Linux with X11" command in make.sh
+//#define INTERACTIVE_GRAPHICS // enable interactive graphics; start/pause the simulation by pressing P; either Windows or Linux X11 or macOS XQuartz desktop must be available; on Linux: change to "compile on Linux with X11" command in make.sh
 //#define INTERACTIVE_GRAPHICS_ASCII // enable interactive graphics in ASCII mode the console; start/pause the simulation by pressing P
 //#define GRAPHICS // run FluidX3D in the console, but still enable graphics functionality for writing rendered frames to the hard drive
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -688,19 +688,41 @@ int main(int argc, char* argv[]) {
 	if(!x11_display) print_error("No X11 display available.");
 
 	Window x11_root_window = DefaultRootWindow(x11_display);
-	XRRScreenResources* x11_screen_resources = XRRGetScreenResources(x11_display, x11_root_window);
-	XRROutputInfo* x11_output_info = XRRGetOutputInfo(x11_display, x11_screen_resources, XRRGetOutputPrimary(x11_display, x11_root_window));
-	XRRCrtcInfo* x11_crtc_info = XRRGetCrtcInfo(x11_display, x11_screen_resources, x11_output_info->crtc);
+	// TODO: only skip these XRR tasks on macOS
+	// erroneously returns nil on macOS
+	//XRRScreenResources* x11_screen_resources = XRRGetScreenResources(x11_display, x11_root_window);
+	// depends on x11_screen_resources
+	//XRROutputInfo* x11_output_info = XRRGetOutputInfo(x11_display, x11_screen_resources, XRRGetOutputPrimary(x11_display, x11_root_window));
+	// depends on x11_screen_resources
+	//XRRCrtcInfo* x11_crtc_info = XRRGetCrtcInfo(x11_display, x11_screen_resources, x11_output_info->crtc);
 	XRRScreenConfiguration* x11_screen_configuration = XRRGetScreenInfo(x11_display, x11_root_window);
-	const uint width  = (uint)x11_crtc_info->width; // width and height of primary monitor
-	const uint height = (uint)x11_crtc_info->height;
-	const int window_offset_x = (int)x11_crtc_info->x; // offset of primary monitor in multi-monitor coordinates
-	const int window_offset_y = (int)x11_crtc_info->y;
-	const uint fps_limit = (uint)XRRConfigCurrentRate(x11_screen_configuration);
+	// depends on x11_screen_resources
+	//const uint width  = (uint)x11_crtc_info->width; // width and height of primary monitor
+	// depends on x11_screen_resources
+	//const uint height = (uint)x11_crtc_info->height;
+	// hardcode
+	const uint width = 800;
+	// hardcode
+	const uint height = 600;
+	// hardcode
+	const int window_offset_x = 50;
+	// hardcode
+	const int window_offset_y = 50;
+	// depends on x11_screen_resources
+	//const int window_offset_x = (int)x11_crtc_info->x; // offset of primary monitor in multi-monitor coordinates
+	// depends on x11_screen_resources
+	//const int window_offset_y = (int)x11_crtc_info->y;
+	// always returns 1 on macOS
+	//const uint fps_limit = (uint)XRRConfigCurrentRate(x11_screen_configuration);
+	// hardcode
+	const uint fps_limit = 60;
 	XRRFreeScreenConfigInfo(x11_screen_configuration);
-	XRRFreeCrtcInfo(x11_crtc_info);
-	XRRFreeOutputInfo(x11_output_info);
-	XRRFreeScreenResources(x11_screen_resources);
+	// depends on x11_screen_resources
+	//XRRFreeCrtcInfo(x11_crtc_info);
+	// depends on x11_screen_resources
+	//XRRFreeOutputInfo(x11_output_info);
+	// depends on x11_screen_resources
+	//XRRFreeScreenResources(x11_screen_resources);
 
 	camera = Camera(width, height, fps_limit);
 


### PR DESCRIPTION
Tested on Apple M2 (Sequoia). Bypasses XRandR failures mentioned here: https://github.com/ProjectPhysX/FluidX3D/issues/191#issue-2335729259

Works & runs well but has some graphical bugs. 

![Screenshot](https://github.com/user-attachments/assets/ceb6a68d-b28a-479c-b14a-b41a5b7c3b8c)

TODO before merging:
- [ ] Choose whether to autodetect or use hardcoded resolution / offset / framerate in main() based on the OS, or gracefully catch XRRGetScreenResources() return failure. 
- [ ] Fix graphical bugs.