### PR TITLE
Fix vertical slice artifacts in mesh voxelization

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -2304,7 +2304,13 @@ string opencl_c_container() { return R( // ########################## begin of O
 	const float cx=bbu[ 7], cy=bbu[ 8], cz=bbu[ 9], ux=bbu[10], uy=bbu[11], uz=bbu[12], rx=bbu[13], ry=bbu[14], rz=bbu[15];
 	const uint3 xyz = direction==0u ? (uint3)((uint)clamp((int)x0-def_Ox, 0, (int)def_Nx-1), a%def_Ny, a/def_Ny) : direction==1u ? (uint3)(a/def_Nz, (uint)clamp((int)y0-def_Oy, 0, (int)def_Ny-1), a%def_Nz) : (uint3)(a%def_Nx, a/def_Nx, (uint)clamp((int)z0-def_Oz, 0, (int)def_Nz-1));
 	const float3 offset = (float3)(0.5f*(float)((int)def_Nx+2*def_Ox)-0.5f, 0.5f*(float)((int)def_Ny+2*def_Oy)-0.5f, 0.5f*(float)((int)def_Nz+2*def_Oz)-0.5f);
-	const float3 r_origin = position(xyz)+offset;
+
+	float3 r_origin = position(xyz)+offset;
+	const float jitter = 0.001f; // 0.1% of voxel size
+	r_origin = r_origin + (float3)(jitter*(float)(direction!=0u),
+								jitter*(float)(direction!=1u),
+								jitter*(float)(direction!=2u));
+
 	const float3 r_direction = (float3)((float)(direction==0u), (float)(direction==1u), (float)(direction==2u));
 	uint intersections=0u, intersections_check=0u;
 	ushort distances[64]; // allow up to 64 mesh intersections


### PR DESCRIPTION
# Fix: STL Voxelization Artifacts (Vertical Slices)

## Problem

When voxelizing STL meshes with regular grid structures (e.g., terrain generated from height maps), vertical slice artifacts appear in the voxelized output. These manifest as missing voxels forming vertical gaps through the geometry.

### Root Cause

The `voxelize_mesh` kernel uses ray-triangle intersection (Moeller-Trumbore algorithm) to determine if voxels are inside or outside the mesh. The algorithm becomes numerically unstable when rays align exactly with mesh vertices or edges.

For meshes with regular grid topology (common in terrain/heightmap data), ray origins often fall exactly on vertex planes, causing:
- Undefined or inconsistent intersection results
- Missed intersections due to floating-point edge cases
- Visible vertical slices in the final voxelization

## Solution

Add a small jitter (0.1% of voxel size) to ray origins perpendicular to the ray direction. This ensures rays never start exactly on mesh vertex planes while maintaining voxelization accuracy.

### Code Change

**File:** `src/kernel.cpp` (in `voxelize_mesh` kernel)

```cpp
// Before
const float3 r_origin = position(xyz)+offset;

// After
float3 r_origin = position(xyz)+offset;

const float jitter = 0.001f; // 0.1% of voxel size
r_origin = r_origin + (float3)(jitter*(float)(direction!=0u),
                            jitter*(float)(direction!=1u),
                            jitter*(float)(direction!=2u));
```

### How It Works

1. **Jitter magnitude:** 0.001 (0.1% of voxel size) is small enough to not affect accuracy but large enough to avoid exact vertex alignment
2. **Direction-aware offset:** Jitter is applied only perpendicular to the ray direction using `(direction!=N)` masks
3. **Result:** Ray-triangle intersections produce stable, well-defined results

## Testing

Tested with `hill.stl` terrain mesh (421 Y-aligned planes, regular grid structure):
- Before: Visible vertical slice artifacts
- After: Clean voxelization without gaps

## Notes

- This fix addresses the coplanarity problem inherent in ray-mesh intersection algorithms
- The 0.1% offset is imperceptible in the final simulation
- Alternative approach: Use SDF (Signed Distance Field) files which bypass ray-tracing entirely
