### PR TITLE
Fixing exit crash.

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -537,12 +537,13 @@ INT WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ PSTR, _In_
 	Clock clock;
 	double frametime = 1.0;
 	MSG msg = { 0 };
-	while(msg.message!=WM_QUIT) {
+	while(msg.message!=WM_QUIT && running) {
 		while(PeekMessage(&msg, 0, 0, 0, PM_REMOVE)) {
 			if(msg.message==WM_QUIT) break;
 			TranslateMessage(&msg);
 			DispatchMessage(&msg);
 		}
+		if(!running) break;
 		// main loop ################################################################
 		camera.rendring_frame.lock(); // block rendering for other threads until finished
 		camera.update_state(fmax(1.0/(double)camera.fps_limit, frametime));

--- a/src/graphics.hpp
+++ b/src/graphics.hpp
@@ -109,7 +109,7 @@ public:
 			case '+': input_scroll_down(); break;
 			case '-': input_scroll_up(); break;
 			case 'F': input_F(); break;
-			case 27: running=false; println(); exit(0);
+			case 27: running=false; break; // signal threads to exit cleanly (don't call exit() - causes heap corruption)
 		}
 #ifdef INTERACTIVE_GRAPHICS_ASCII
 		if(free) { // move free camera

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -147,7 +147,8 @@ void main_physics() {
 	info.print_logo();
 	main_setup(); // execute setup
 	running = false;
-	exit(0); // make sure that the program stops
+	// Don't call exit(0) here - let main thread join and exit cleanly
+	// exit(0) causes heap corruption due to race conditions with other threads
 }
 
 #ifndef GRAPHICS


### PR DESCRIPTION
# Fix: Heap Corruption Crash on ESC Exit

## Problem

Pressing ESC to exit the simulation causes a heap corruption crash with the error:
```
Debug Assertion Failed!
Expression: _CrtIsValidHeapPointer(block)
```

This occurs in debug builds and can cause undefined behavior in release builds.

## Root Cause

The application calls `exit(0)` from multiple locations without proper thread synchronization:

1. **graphics.hpp:112** - Called from the graphics/input thread when ESC is pressed
2. **main.cpp:150** - Called from the compute thread when simulation ends

When `exit(0)` is called:
- It terminates all threads immediately
- Global/static destructors are invoked
- Local objects on other threads' stacks are NOT properly destroyed
- Race conditions occur between memory operations in the compute thread and cleanup in the graphics thread

This causes heap corruption because:
- The compute thread may be in the middle of memory allocation/deallocation
- The LBM object's destructor may not be called properly
- Multiple threads may attempt to free the same memory

## Solution

Replace immediate `exit(0)` calls with clean shutdown via the `running` flag:

### 1. graphics.hpp (ESC key handler)
```cpp
// Before:
case 27: running=false; println(); exit(0);

// After:
case 27: running=false; break;
```

### 2. main.cpp (main_physics function)
```cpp
// Before:
void main_physics() {
    info.print_logo();
    main_setup();
    running = false;
    exit(0);
}

// After:
void main_physics() {
    info.print_logo();
    main_setup();
    running = false;
    // Let main thread join and exit cleanly
}
```

### 3. graphics.cpp (Windows main loop)
```cpp
// Before:
while(msg.message!=WM_QUIT) {
    while(PeekMessage(&msg, 0, 0, 0, PM_REMOVE)) {
        ...
    }

// After:
while(msg.message!=WM_QUIT && running) {
    while(PeekMessage(&msg, 0, 0, 0, PM_REMOVE)) {
        ...
    }
    if(!running) break;
```

## How It Works Now

1. ESC pressed → `running = false`
2. Windows main loop checks `running` and exits
3. `lbm.run()` checks `running` and exits its loop (already implemented)
4. `compute_thread.join()` waits for compute thread to finish
5. LBM destructor is called properly
6. Program exits cleanly via `return 0` from `main()`

## Files Changed

| File | Change | Platform |
|------|--------|----------|
| `src/graphics.hpp` | Remove `exit(0)` from ESC handler | All |
| `src/main.cpp` | Remove `exit(0)` from `main_physics()` | All |
| `src/graphics.cpp` | Add `running` check to Windows main loop | Windows |

Note: The Linux main loop already uses `while(running)` so no changes were needed there.
